### PR TITLE
fix: prevent body DoS and Prometheus label injection in telemetry handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,26 @@ func forwardToPrometheus(metrics []byte, forwardURL string) error {
 	return nil
 }
 
+// maxTelemetryBodySize is the maximum accepted size for a telemetry POST body.
+const maxTelemetryBodySize = 10 * 1024 * 1024 // 10 MB
+
+// isValidClusterID accepts only alphanumeric characters, hyphens, underscores,
+// and dots (standard Kubernetes naming). This prevents Prometheus text-format
+// injection via the X-Cluster-ID header (e.g. a value containing '"' or '\n'
+// would corrupt the label output forwarded to VictoriaMetrics).
+func isValidClusterID(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.') {
+			return false
+		}
+	}
+	return true
+}
+
 func handleTelemetry(w http.ResponseWriter, r *http.Request, forwardURL string) {
 	startTime := time.Now()
 
@@ -113,12 +133,13 @@ func handleTelemetry(w http.ResponseWriter, r *http.Request, forwardURL string) 
 	}
 
 	clusterID := r.Header.Get("X-Cluster-ID")
-	if clusterID == "" {
-		log.Printf("Request rejected: missing X-Cluster-ID header")
-		http.Error(w, "X-Cluster-ID header is required", http.StatusBadRequest)
+	if !isValidClusterID(clusterID) {
+		log.Printf("Request rejected: invalid or missing X-Cluster-ID header")
+		http.Error(w, "X-Cluster-ID header is required and must contain only alphanumeric characters, hyphens, underscores, or dots", http.StatusBadRequest)
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxTelemetryBodySize)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("Error reading request body: %v", err)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -142,6 +143,11 @@ func handleTelemetry(w http.ResponseWriter, r *http.Request, forwardURL string) 
 	r.Body = http.MaxBytesReader(w, r.Body, maxTelemetryBodySize)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			log.Printf("Request from cluster %s rejected: body exceeded %d bytes limit", clusterID, maxBytesErr.Limit)
+			return
+		}
 		log.Printf("Error reading request body: %v", err)
 		http.Error(w, fmt.Sprintf("Error reading request: %v", err), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Summary

Two security issues found during review of #3, both in the existing telemetry ingestion handler:

- **Memory exhaustion (DoS)**: `io.ReadAll(r.Body)` had no size limit — any client could POST an arbitrarily large body and exhaust pod memory. Fixed with `http.MaxBytesReader` capped at 10 MB.
- **Prometheus label injection**: `X-Cluster-ID` header value was used directly as a Prometheus label value without validation. A value containing `"`, `\n`, or `}` would corrupt the text-format output forwarded to VictoriaMetrics (e.g. `X-Cluster-ID: foo",injected="bar` would produce broken metrics). Fixed by validating the header against `[a-zA-Z0-9._-]` (max 253 chars, matching Kubernetes naming rules) and rejecting with 400 otherwise.

## Test plan

- [ ] POST with a body > 10 MB returns 413
- [ ] POST with `X-Cluster-ID: foo"bar` returns 400
- [ ] POST with `X-Cluster-ID: valid-cluster.name_01` is accepted as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented a 10 MB size limit for incoming telemetry request bodies to prevent resource exhaustion.
  * Enhanced cluster ID header validation with stricter format requirements and more descriptive error messages for invalid or missing values.
  * Improved error handling to gracefully manage oversized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->