### PR TITLE
fix(overview): keep current-month snapshots live and query Tenant kind correctly

### DIFF
--- a/overview.go
+++ b/overview.go
@@ -103,27 +103,33 @@ func NewOverviewManager(vmSelectURL, snapshotDir string) *OverviewManager {
 // VictoriaMetrics on every call and never persisted to disk — the month is
 // still in flight, so caching would freeze the data.
 //
-// For past months the snapshot is looked up in memory first, then on disk,
-// and only generated via VM when absent. Concurrent calls for the same past
-// month are coalesced by singleflight.
+// For past months a *final* in-memory snapshot is reused; non-final entries
+// (e.g. an in-progress April snapshot that survives the May 1 boundary in a
+// long-running process) are treated as cache misses so the regen path runs
+// and produces a final end-of-month snapshot that overwrites the stale one.
+//
+// Concurrent calls for the same month — current or past — are coalesced by
+// singleflight, so a burst of N parallel requests triggers one VictoriaMetrics
+// fetch, not N.
 func (m *OverviewManager) ensureSnapshot(monthLabel string) {
-	if m.isCurrentOrFutureMonth(monthLabel) {
-		// In-progress month: always regenerate. collectSnapshot will choose
-		// in-memory-only storage because the resulting snapshot is non-final.
-		m.collectSnapshot(monthLabel)
-		return
-	}
+	current := m.isCurrentOrFutureMonth(monthLabel)
 
-	if m.hasSnapshot(monthLabel) {
-		return
-	}
-
-	// Try loading from disk cache before querying VM.
-	if m.loadSnapshotFromDisk(monthLabel) {
-		return
+	if !current {
+		if m.hasFinalSnapshot(monthLabel) {
+			return
+		}
+		// Try loading from disk cache before querying VM. The on-disk file
+		// for a current month is by definition non-final and loadSnapshotFromDisk
+		// would ignore it anyway, so this is only useful for past months.
+		if m.loadSnapshotFromDisk(monthLabel) {
+			return
+		}
 	}
 
 	// Singleflight: only one goroutine generates a given month at a time.
+	// Applies to both current and past months — for the current month, this
+	// lets concurrent /api/overview callers share one VictoriaMetrics fetch
+	// instead of fanning out to N parallel queries.
 	m.inflightMu.Lock()
 	if wg, ok := m.inflight[monthLabel]; ok {
 		// Another goroutine is already generating this month — wait for it.
@@ -162,12 +168,14 @@ func isFinalSnapshot(s Snapshot) bool {
 	return !s.CollectedAt.Before(endOfMonth)
 }
 
-// hasSnapshot reports whether monthLabel is already in the in-memory list.
-func (m *OverviewManager) hasSnapshot(monthLabel string) bool {
+// hasFinalSnapshot reports whether a final snapshot for monthLabel — one
+// collected after the month ended — is already in the in-memory list. Non-final
+// entries do not count: see ensureSnapshot for why.
+func (m *OverviewManager) hasFinalSnapshot(monthLabel string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, s := range m.snapshots {
-		if s.Month == monthLabel {
+		if s.Month == monthLabel && isFinalSnapshot(s) {
 			return true
 		}
 	}

--- a/overview.go
+++ b/overview.go
@@ -97,11 +97,23 @@ func NewOverviewManager(vmSelectURL, snapshotDir string) *OverviewManager {
 	return m
 }
 
-// ensureSnapshot guarantees the snapshot for monthLabel is in memory.
-// It tries memory first, then disk cache, then generates it from VictoriaMetrics.
-// Concurrent calls for the same month are coalesced: only one goroutine runs
-// the generation and the rest wait for it to complete.
+// ensureSnapshot guarantees the snapshot for monthLabel is available in memory.
+//
+// For the current (in-progress) month the snapshot is regenerated from
+// VictoriaMetrics on every call and never persisted to disk — the month is
+// still in flight, so caching would freeze the data.
+//
+// For past months the snapshot is looked up in memory first, then on disk,
+// and only generated via VM when absent. Concurrent calls for the same past
+// month are coalesced by singleflight.
 func (m *OverviewManager) ensureSnapshot(monthLabel string) {
+	if m.isCurrentOrFutureMonth(monthLabel) {
+		// In-progress month: always regenerate. collectSnapshot will choose
+		// in-memory-only storage because the resulting snapshot is non-final.
+		m.collectSnapshot(monthLabel)
+		return
+	}
+
 	if m.hasSnapshot(monthLabel) {
 		return
 	}
@@ -134,6 +146,22 @@ func (m *OverviewManager) ensureSnapshot(monthLabel string) {
 	m.collectSnapshot(monthLabel)
 }
 
+// isCurrentOrFutureMonth reports whether monthLabel refers to the current
+// (in-progress) calendar month or a future month. Past months are final and
+// safe to cache; current and future months are not.
+func (m *OverviewManager) isCurrentOrFutureMonth(monthLabel string) bool {
+	return monthLabel >= time.Now().UTC().Format("2006-01")
+}
+
+// isFinalSnapshot reports whether a snapshot was collected after its month
+// ended — i.e. whether it represents the complete, frozen state of that month
+// rather than an in-progress reading that will still change.
+func isFinalSnapshot(s Snapshot) bool {
+	t := parseMonth(s.Month)
+	endOfMonth := time.Date(t.Year(), t.Month()+1, 0, 23, 59, 59, 0, time.UTC)
+	return !s.CollectedAt.Before(endOfMonth)
+}
+
 // hasSnapshot reports whether monthLabel is already in the in-memory list.
 func (m *OverviewManager) hasSnapshot(monthLabel string) bool {
 	m.mu.RLock()
@@ -148,6 +176,9 @@ func (m *OverviewManager) hasSnapshot(monthLabel string) bool {
 
 // loadSnapshotFromDisk tries to read a cached snapshot file for monthLabel.
 // Returns true if the snapshot was found and loaded into memory.
+//
+// Non-final (in-progress) snapshots are treated as if the file were missing
+// so the caller falls back to regenerating from VictoriaMetrics.
 func (m *OverviewManager) loadSnapshotFromDisk(monthLabel string) bool {
 	filename := filepath.Join(m.snapshotDir, monthLabel+".json")
 	data, err := os.ReadFile(filename)
@@ -156,6 +187,11 @@ func (m *OverviewManager) loadSnapshotFromDisk(monthLabel string) bool {
 	}
 	var s Snapshot
 	if err := json.Unmarshal(data, &s); err != nil {
+		return false
+	}
+	if !isFinalSnapshot(s) {
+		log.Printf("Ignoring non-final snapshot on disk for %s (CollectedAt %s before end of month)",
+			monthLabel, s.CollectedAt.Format(time.RFC3339))
 		return false
 	}
 	m.mu.Lock()
@@ -207,8 +243,8 @@ func (m *OverviewManager) collectSnapshot(monthLabel string) {
 		snapshot.TotalNodes = int(nodes)
 	}
 
-	// Query total tenants (tenant is an application kind)
-	tenants, err := m.queryScalar(`sum(cozy_application_count{kind="tenant"})`, queryAt)
+	// Query total tenants (Tenant is an application kind)
+	tenants, err := m.queryScalar(`sum(cozy_application_count{kind="Tenant"})`, queryAt)
 	if err != nil {
 		log.Printf("Error querying total tenants: %v", err)
 	} else {
@@ -252,10 +288,16 @@ func (m *OverviewManager) collectSnapshot(monthLabel string) {
 		return
 	}
 
-	// Save snapshot
-	m.saveSnapshot(snapshot)
-	log.Printf("Snapshot for %s collected: %d clusters, %d nodes, %d tenants, %d app types",
-		monthLabel, snapshot.Clusters, snapshot.TotalNodes, snapshot.TotalTenants, len(snapshot.Apps))
+	// Only final (end-of-month) snapshots are written to disk. In-progress
+	// snapshots for the current month are held in memory and replaced on each
+	// request, so the API always reflects live VM state.
+	if isFinalSnapshot(snapshot) {
+		m.saveSnapshot(snapshot)
+	} else {
+		m.storeSnapshotInMemory(snapshot)
+	}
+	log.Printf("Snapshot for %s collected: %d clusters, %d nodes, %d tenants, %d app types (final=%t)",
+		monthLabel, snapshot.Clusters, snapshot.TotalNodes, snapshot.TotalTenants, len(snapshot.Apps), isFinalSnapshot(snapshot))
 }
 
 type vectorResult struct {
@@ -417,6 +459,13 @@ func (m *OverviewManager) saveSnapshot(s Snapshot) {
 		return
 	}
 
+	m.storeSnapshotInMemory(s)
+}
+
+// storeSnapshotInMemory inserts or replaces a snapshot in the in-memory list
+// without touching disk. Used both by saveSnapshot (after the disk write) and
+// for non-final current-month snapshots that must not be persisted.
+func (m *OverviewManager) storeSnapshotInMemory(s Snapshot) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -463,6 +512,11 @@ func (m *OverviewManager) loadSnapshots() {
 		var s Snapshot
 		if err := json.Unmarshal(data, &s); err != nil {
 			log.Printf("Warning: cannot parse snapshot %s: %v", e.Name(), err)
+			continue
+		}
+		if !isFinalSnapshot(s) {
+			log.Printf("Skipping non-final snapshot %s (CollectedAt %s before end of month)",
+				e.Name(), s.CollectedAt.Format(time.RFC3339))
 			continue
 		}
 		m.snapshots = append(m.snapshots, s)


### PR DESCRIPTION
## Summary

The `/api/overview` endpoint currently freezes the current-month snapshot at the first request of the month. For April 2026 this has been returning 43 clusters / 164 nodes / 83 tenants since April 1, while live VictoriaMetrics has climbed to 112 / 450 / 444 as of 2026-04-22.

Two bugs fixed:

1. **Current-month snapshots are now regenerated on every request** and never written to disk. Only final end-of-month snapshots are persisted. Non-final snapshots already on the PVC (e.g. the stale `2026-04.json` from April 1) are ignored on load, so the existing file self-heals at month turnover.
2. **`total_tenants` was always 0** because the scalar query used `kind="tenant"` while the emitted metric label is `kind="Tenant"` (see client code in `cozystack/cozystack/internal/telemetry` and docs `v1/operations/configuration/telemetry.md`). Fixed to match the real label.

## What

- `overview.go`:
  - `ensureSnapshot`: for the current/future calendar month, skip memory+disk cache and always call `collectSnapshot`.
  - `collectSnapshot`: persist only when `isFinalSnapshot(s)`; otherwise store in memory via the new `storeSnapshotInMemory` helper.
  - `loadSnapshots` + `loadSnapshotFromDisk`: skip non-final files so the legacy stale April file does not repopulate the cache.
  - `saveSnapshot` delegates the in-memory update to `storeSnapshotInMemory` (no behaviour change).
  - New helpers: `isCurrentOrFutureMonth`, `isFinalSnapshot`.
- Tenant query: `kind="tenant"` → `kind="Tenant"`.

## Why

Without this fix every current-month snapshot reflects whatever VM reported at the first request that month — frozen until the month ends. The website fetches this endpoint daily and exposes the stale number on `cozystack.io/oss-health/telemetry/`. The Tenant-label bug hid behind a workaround in the website fetcher that reads `apps.Tenant` instead of `total_tenants`; that workaround still works after this fix and can be dropped in a follow-up.

## Operational note

After deployment the stale `2026-04.json` on the PVC stays, but is no longer read (`isFinalSnapshot` = false). On May 1 a correct end-of-April snapshot will be generated and overwrite it. No manual cleanup needed.

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass (done locally)
- [ ] Deploy to staging; request `/api/overview?year=2026&month=04` twice and confirm the response tracks live VM, not a frozen value
- [ ] Request a past month (e.g. `?year=2026&month=03`) and confirm it stays cached
- [ ] Verify `total_tenants` is non-zero and matches `sum(cozy_application_count{kind="Tenant"})`
- [ ] After 2026-05-01, confirm April snapshot on disk has been regenerated with `CollectedAt` past end of April